### PR TITLE
vpkcreate: remove erroneous repeat root from path

### DIFF
--- a/cmd/vpkcreate/main.go
+++ b/cmd/vpkcreate/main.go
@@ -46,7 +46,7 @@ func main() {
 			}
 
 			if !info.IsDir() {
-				contents = append(contents, entry(filepath.Join(name, path)))
+				contents = append(contents, entry(path))
 			}
 
 			return nil


### PR DESCRIPTION
filepath.Walk already includes the root with the path there is no need
to do `filepath.Join(root, path)` this just results in a repeat root in
the path which leads to errors in every scenario
except when current dir (`.`) is used